### PR TITLE
Fix Profile and Notifications Issue, retry unpausing if it failed.

### DIFF
--- a/Youtube-Ad-blocker-Reminder-Remover
+++ b/Youtube-Ad-blocker-Reminder-Remover
@@ -8,8 +8,8 @@
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=youtube.com
 // @grant        none
 // ==/UserScript==
-
-(function () {
+(function()
+{
     // Specify domains and JSON paths to remove
     const domainsToRemove = [
         '*.youtube-nocookie.com/*'
@@ -25,58 +25,112 @@
 
     const debug = true; // Set to false to disable debug messages
 
+    let unpausedAfterSkip = 0; //This is used to check if the video has been unpaused already
+
     if (debug) console.log("Script started");
 
     // Old variable but could work in some cases
     window.__ytplayer_adblockDetected = false;
 
     removeJsonPaths(domainsToRemove, jsonPathsToRemove);
-    setInterval(() => {
-    const popup = document.querySelector("body > ytd-app > ytd-popup-container");
-        if (popup) {
+    setInterval(() =>
+    {
+        const popup = document.querySelector("body > ytd-app > ytd-popup-container > tp-yt-paper-dialog");
+        if (popup)
+        {
             if (debug) console.log("Remove Adblock Thing: Popup detected, removing...");
-
             popup.remove();
-
-            // Check if the video is paused
-            const video = document.querySelector("#movie_player > video.html5-main-video");
-            if (video && video.paused) {
-        // Simulate pressing the "k" key to unpause the video
-        const keyEvent = new KeyboardEvent("keydown", {
-          key: "k",
-          code: "KeyK",
-          keyCode: 75,
-          which: 75,
-          bubbles: true,
-          cancelable: true,
-          view: window
-        });
-        document.dispatchEvent(keyEvent);
-        if (debug) console.log("Remove Adblock Thing: Unpaused video using 'k' key");
-      }
-
+            unpausedAfterSkip = 2;
             if (debug) console.log("Remove Adblock Thing: Popup removed");
         }
+
+        // Check if the video is paused after removing the popup
+        if (unpausedAfterSkip > 0)
+        {
+            console.log("pong");
+            const video1 = document.querySelector("#movie_player > video.html5-main-video");
+            const video2 = document.querySelector("#movie_player > .html5-video-container > video");
+            if (video1)
+            {
+                if (video1.paused)
+                {
+                    // Simulate pressing the "k" key to unpause the video
+                    const keyEvent = new KeyboardEvent("keydown",
+                    {
+                        key: "k",
+                        code: "KeyK",
+                        keyCode: 75,
+                        which: 75,
+                        bubbles: true,
+                        cancelable: true,
+                        view: window
+                    });
+                    document.dispatchEvent(keyEvent);
+                    unpausedAfterSkip = 0;
+                    if (debug) console.log("Remove Adblock Thing: Unpaused video using 'k' key");
+                }
+                else if (unpausedAfterSkip > 0)
+                {
+                    unpausedAfterSkip--;
+                }
+            }
+            if (video2)
+            {
+                if (video2.paused)
+                {
+                    // Simulate pressing the "k" key to unpause the video
+                    const keyEvent = new KeyboardEvent("keydown",
+                    {
+                        key: "k",
+                        code: "KeyK",
+                        keyCode: 75,
+                        which: 75,
+                        bubbles: true,
+                        cancelable: true,
+                        view: window
+                    });
+                    document.dispatchEvent(keyEvent);
+                    unpausedAfterSkip = 0;
+                    if (debug) console.log("Remove Adblock Thing: Unpaused video using 'k' key");
+                }
+                else if (unpausedAfterSkip > 0)
+                {
+                    unpausedAfterSkip--;
+                }
+            }
+        }
+
     }, 1000);
 
     // Observe and remove ads when new content is loaded dynamically
-    const observer = new MutationObserver(() => {
+    const observer = new MutationObserver(() =>
+    {
         removeJsonPaths(domainsToRemove, jsonPathsToRemove);
     });
 
-    const observerConfig = { childList: true, subtree: true };
+    const observerConfig = {
+        childList: true,
+        subtree: true
+    };
     observer.observe(document.body, observerConfig);
 
-    function removeJsonPaths(domains, jsonPaths) {
+    function removeJsonPaths(domains, jsonPaths)
+    {
         const currentDomain = window.location.hostname;
-        if (domains.includes(currentDomain)) {
-            jsonPaths.forEach(jsonPath => {
+        if (domains.includes(currentDomain))
+        {
+            jsonPaths.forEach(jsonPath =>
+            {
                 const pathParts = jsonPath.split('.');
                 let obj = window;
-                for (const part of pathParts) {
-                    if (obj.hasOwnProperty(part)) {
+                for (const part of pathParts)
+                {
+                    if (obj.hasOwnProperty(part))
+                    {
                         obj = obj[part];
-                    } else {
+                    }
+                    else
+                    {
                         break;
                     }
                 }
@@ -87,4 +141,3 @@
 
 
 })();
-


### PR DESCRIPTION
The Profile and Notifications issue is due to removing the entire "ytd-popup-container" instead of just the adblock thing "tp-yt-paper-dialog". The unpausing retrying is because sometimes the adblock popup is removed before the video loads (and so video.paused returns false or null), by letting it retry unpausing it always ensure that the video is unpaused after removing the popup.