### PR TITLE
YouTube Remove Adblock Thing 2.3

### DIFF
--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -126,6 +126,28 @@
     }
     // undetected adblocker method
     function addblocker() {
+
+        // Do not display as they will be deleted
+        const css = 
+            `
+            .ad-showing, .videoAdUiSkipButton, .ytp-ad-skip-button, .ytp-ad-skip-button-modern { display: none; }
+            ytd-action-companion-ad-renderer { display: none; }
+            div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint { display: none; }
+            div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer { display: none; }
+            div#main-container.style-scope.ytd-promoted-video-renderer { display: none; }
+            ytd-in-feed-ad-layout-renderer { display: none; }
+            .ytd-video-masthead-ad-v3-renderer { display: none; }
+            ytd-engagement-panel-section-list-renderer[target-id="engagement-panel-ads"] { display: none; }
+            ytd-merch-shelf-renderer { display: none; }
+            .ytd-banner-promo-renderer { display: none; }
+        `;
+        const head = document.head || document.getElementsByTagName('head')[0];
+        const styleElement = document.createElement('style');
+        styleElement.type = 'text/css';
+        styleElement.id = 'adSkip'; // for debug: document.querySelector('#adSkip').remove()
+        styleElement.innerHTML = css;
+        head.appendChild(styleElement);
+
         handleAds();
 
         // Add a popup if the cookie does not exist

--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Remove Adblock Thing
 // @namespace    http://tampermonkey.net/
-// @version      2.1
+// @version      2.3
 // @description  Removes Adblock Thing
 // @author       JoelMatic
 // @match        https://www.youtube.com/*
@@ -11,8 +11,7 @@
 // @grant        none
 // ==/UserScript==
 
-(function()
- {
+(function () {
     //
     //      Config
     //
@@ -50,19 +49,19 @@
     };
 
     const keyEvent = new KeyboardEvent("keydown", {
-      key: "k",
-      code: "KeyK",
-      keyCode: 75,
-      which: 75,
-      bubbles: true,
-      cancelable: true,
-      view: window
+        key: "k",
+        code: "KeyK",
+        keyCode: 75,
+        which: 75,
+        bubbles: true,
+        cancelable: true,
+        view: window
     });
 
     let mouseEvent = new MouseEvent("click", {
-      bubbles: true,
-      cancelable: true,
-      view: window,
+        bubbles: true,
+        cancelable: true,
+        view: window,
     });
 
     //This is used to check if the video has been unpaused already
@@ -72,9 +71,9 @@
     // Old variable but could work in some cases
     window.__ytplayer_adblockDetected = false;
 
-    if(adblocker) addblocker();
-    if(removePopup) popupRemover();
-    if(removePopup) observer.observe(document.body, observerConfig);
+    if (adblocker) addblocker();
+    if (removePopup) popupRemover();
+    //if (removePopup) observer.observe(document.body, observerConfig);
 
     // Remove Them pesski popups
     function popupRemover() {
@@ -102,15 +101,15 @@
             if (popup) {
                 if (debug) console.log("Remove Adblock Thing: Popup detected, removing...");
 
-                if(popupButton) popupButton.click();
+                if (popupButton) popupButton.click();
                 // if(popupButton2) popupButton2.click();
                 popup.remove();
                 unpausedAfterSkip = 2;
 
                 fullScreenButton.dispatchEvent(mouseEvent);
-              
+
                 setTimeout(() => {
-                  fullScreenButton.dispatchEvent(mouseEvent);
+                    fullScreenButton.dispatchEvent(mouseEvent);
                 }, 500);
 
                 if (debug) console.log("Remove Adblock Thing: Popup removed");
@@ -126,53 +125,33 @@
         }, 1000);
     }
     // undetected adblocker method
-    function addblocker()
-    {
-        setInterval(() =>
-                    {
-            const skipBtn = document.querySelector('.videoAdUiSkipButton,.ytp-ad-skip-button');
-            const ad = [...document.querySelectorAll('.ad-showing')][0];
-            const sidAd = document.querySelector('ytd-action-companion-ad-renderer');
-            const displayAd = document.querySelector('div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint');
-            const sparklesContainer = document.querySelector('div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer');
-            const mainContainer = document.querySelector('div#main-container.style-scope.ytd-promoted-video-renderer');
-            const feedAd = document.querySelector('ytd-in-feed-ad-layout-renderer');
-            const mastheadAd = document.querySelector('.ytd-video-masthead-ad-v3-renderer');
-            const sponsor = document.querySelectorAll("div#player-ads.style-scope.ytd-watch-flexy, div#panels.style-scope.ytd-watch-flexy");
-            const nonVid = document.querySelector(".ytp-ad-skip-button-modern");
+    function addblocker() {
+        handleAds();
 
-            if (ad)
-            {
-                const video = document.querySelector('video');
-                video.playbackRate = 10;
-                video.volume = 0;
-                video.currentTime = video.duration;
-                skipBtn?.click();
+        // Add a popup if the cookie does not exist
+        setTimeout(() => {
+            if (!getGotItState()) {
+                document.body.insertAdjacentHTML("beforeend", addCss() + addHtml());
+
+                const modal = document.getElementById("myModal");
+                const span = document.getElementsByClassName("close")[0];
+
+                modal.style.display = "block";
+
+                span.onclick = function () {
+                    modal.style.display = "none";
+                }
+
+                document.querySelector('.gotIt').onclick = function () {
+                    setGotItState(true);
+                    modal.style.display = "none";
+                }
             }
+        }, 1000);
 
-            sidAd?.remove();
-            displayAd?.remove();
-            sparklesContainer?.remove();
-            mainContainer?.remove();
-            feedAd?.remove();
-            mastheadAd?.remove();
-            sponsor?.forEach((element) => {
-                 if (element.getAttribute("id") === "panels") {
-                    element.childNodes?.forEach((childElement) => {
-                      if (childElement.data.targetId && childElement.data.targetId !=="engagement-panel-macro-markers-description-chapters")
-                          //Skipping the Chapters section
-                            childElement.remove();
-                          });
-                       } else {
-                           element.remove();
-                       }
-             });
-            nonVid?.click();
-        }, 50)
     }
     // Unpause the video Works most of the time
-    function unPauseVideo(video)
-    {
+    function unPauseVideo(video) {
         if (!video) return;
         if (video.paused) {
             // Simulate pressing the "k" key to unpause the video
@@ -181,8 +160,7 @@
             if (debug) console.log("Remove Adblock Thing: Unpaused video using 'k' key");
         } else if (unpausedAfterSkip > 0) unpausedAfterSkip--;
     }
-    function removeJsonPaths(domains, jsonPaths)
-    {
+    function removeJsonPaths(domains, jsonPaths) {
         const currentDomain = window.location.hostname;
         if (!domains.includes(currentDomain)) return;
 
@@ -191,7 +169,7 @@
             let obj = window;
             let previousObj = null;
             let partToSetUndefined = null;
-        
+
             for (const part of pathParts) {
                 if (obj.hasOwnProperty(part)) {
                     previousObj = obj; // Keep track of the parent object.
@@ -201,16 +179,180 @@
                     break; // Stop when we reach a non-existing part.
                 }
             }
-        
+
             // If we've identified a valid part to set to undefined, do so.
             if (previousObj && partToSetUndefined !== null) {
                 previousObj[partToSetUndefined] = undefined;
             }
         });
     }
+
     // Observe and remove ads when new content is loaded dynamically
-    const observer = new MutationObserver(() =>
-    {
+    /*const observer = new MutationObserver(() => {
         removeJsonPaths(domainsToRemove, jsonPathsToRemove);
-    });
+    });*/
+
+    function getGotItState() {
+        return localStorage.getItem('yAdbgotIt') === 'true';
+    }
+
+    function setGotItState(state) {
+        localStorage.setItem('yAdbgotIt', state.toString());
+    }
+
+    function addCss() {
+        return `
+            <style>
+                .modal {
+                    display: none;
+                    position: fixed;
+                    z-index: 99999;
+                    padding-top: 100px;
+                    left: 0;
+                    top: 0;
+                    width: 100%;
+                    height: 100%;
+                    overflow: auto;
+                    background-color: rgb(0,0,0);
+                    background-color: rgba(0,0,0,0.4);
+                    font-size: 16px;
+                    max-width: 500px;
+                }
+
+                .modal .content { 
+                     margin-top: 30px;
+                }
+                
+                .modal-content {
+                    background-color: #fefefe;
+                    margin: auto;
+                    padding: 20px;
+                    border: 1px solid #888;
+                    width: 80%;
+                    border: 5px #f90000 solid;
+                    border-radius: 10px;
+                }
+                
+                .close {
+                    color: #aaaaaa;
+                    float: right;
+                    font-size: 28px;
+                    font-weight: bold;
+                }
+                
+                .close:hover,
+                .close:focus {
+                    color: #000;
+                    text-decoration: none;
+                    cursor: pointer;
+                }
+            </style>
+        `;
+    }
+
+
+    function addHtml() {
+        if (/fr/.test(navigator.language)) {
+            return `
+                <div id="myModal" class="modal">
+                    <div class="modal-content">
+                    <span class="close">&times;</span>
+                    <div class="content">
+                        <b> AdSkip YouTube </b>:<br>
+                        <b>Pour que ce plugin fonctionne, désactivez votre bloqueur de publicités :</b> ajoutez YouTube à la liste blanche de toutes les extensions Firefox qui bloquent les publicités ou de tout élément tiers qui désactive les publicités. Ne vous inquiétez pas, ce script supprime les publicités intrusives sur les vidéos.
+                        <br><br>
+                        <button class="gotIt">J'ai compris !</button>
+                    </div>
+                </div>
+            </div>
+        `;
+        } else {
+            return `
+                <div id="myModal" class="modal">
+                    <div class="modal-content">
+                        <span class="close">&times;</span>
+                        <div class="content">
+                            <b> AdSkip YouTube </b>:<br>
+                            <b>For this plugin to work, turn off your ad blocker :</b> Add YouTube to the whitelist of all Firefox extensions that block ads or any third-party items that disable ads. Don't worry, this script removes intrusive ads on videos.
+                            <br><br>
+                            <button class="gotIt">Got it !</button>
+                        </div>
+                    </div>
+
+                </div>
+            `;
+        }
+    }
+
+
+    function handleAds() {
+        const skipBtnSelector = '.videoAdUiSkipButton, .ytp-ad-skip-button';
+        const adSelector = '.ad-showing';
+        const adRemovalSelectors = [
+            'ytd-action-companion-ad-renderer',
+            'div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint',
+            'div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer',
+            'div#main-container.style-scope.ytd-promoted-video-renderer',
+            'ytd-in-feed-ad-layout-renderer',
+            '.ytd-video-masthead-ad-v3-renderer',
+            'ytd-engagement-panel-section-list-renderer[target-id="engagement-panel-ads"]',
+            'ytd-merch-shelf-renderer' // Remove store stuff below videos : https://www.zupimages.net/up/23/45/1npf.png
+        ];
+        const sponsorSelectors = ['div#player-ads.style-scope.ytd-watch-flexy', 'div#panels.style-scope.ytd-watch-flexy'];
+        const nonVidSelector = '.ytp-ad-skip-button-modern';
+    
+        const observerCallback = (mutationsList, observer) => {
+            removeJsonPaths(domainsToRemove, jsonPathsToRemove);
+            for (const mutation of mutationsList) {
+                if (mutation.addedNodes.length > 0) {
+                    const video = document.querySelector('video');
+                    const skipBtn = document.querySelector(skipBtnSelector);
+                    const ad = document.querySelector(adSelector);
+    
+                    if (ad) {
+                        video.playbackRate = 10;
+                        video.volume = 0;
+                        video.currentTime = video.duration;
+                        skipBtn?.click();
+                    }
+    
+                    for (const removalSelector of adRemovalSelectors) {
+                        const element = document.querySelector(removalSelector);
+                        element?.remove();
+                    }
+    
+                    const sponsorElements = document.querySelectorAll(sponsorSelectors.join(', '));
+                    sponsorElements.forEach((element) => {
+                        if (element.getAttribute("id") === "panels") {
+                            element.childNodes?.forEach((childElement) => {
+                                if (childElement.data?.targetId && childElement.data.targetId !== "engagement-panel-macro-markers-description-chapters") {
+                                    //Skipping the Chapters section
+                                    childElement.remove();
+                                }
+                            });
+                        } else {
+                            element.remove();
+                        }
+                    });
+    
+                    const nonVid = document.querySelector(nonVidSelector);
+                    nonVid?.click();
+
+                    // On the home page (desktop) at the top left
+                    const parentElement = document.querySelector('ytd-ad-slot-renderer');
+                    if (parentElement) {
+                        const richItemRenderers = parentElement.closest('ytd-app').querySelector('ytd-rich-item-renderer');
+                        richItemRenderers?.remove();
+                    }
+                }
+            }
+        };
+    
+        const observer = new MutationObserver(observerCallback);
+        observer.observe(document.body, observerConfig);
+    }
+    
+
+    
+
 })();

--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -296,7 +296,8 @@
             'ytd-in-feed-ad-layout-renderer',
             '.ytd-video-masthead-ad-v3-renderer',
             'ytd-engagement-panel-section-list-renderer[target-id="engagement-panel-ads"]',
-            'ytd-merch-shelf-renderer' // Remove store stuff below videos : https://www.zupimages.net/up/23/45/1npf.png
+            'ytd-merch-shelf-renderer', // Remove store stuff below videos : https://www.zupimages.net/up/23/45/1npf.png
+            '.ytd-banner-promo-renderer' // Removes the large banner that occasionally appears at the top of the home page offering to subscribe to Premium
         ];
         const sponsorSelectors = ['div#player-ads.style-scope.ytd-watch-flexy', 'div#panels.style-scope.ytd-watch-flexy'];
         const nonVidSelector = '.ytp-ad-skip-button-modern';
@@ -339,11 +340,13 @@
                     nonVid?.click();
 
                     // On the home page (desktop) at the top left
+                    // It works, but sometimes it causes the current page to lag.
+                    /*
                     const parentElement = document.querySelector('ytd-ad-slot-renderer');
                     if (parentElement) {
                         const richItemRenderers = parentElement.closest('ytd-app').querySelector('ytd-rich-item-renderer');
                         richItemRenderers?.remove();
-                    }
+                    }*/
                 }
             }
         };


### PR DESCRIPTION
Tested on firefox only

List of improvements:

- The addblocker::setInterval is replaced by a MutationObserver. It's better for performance to avoid something that runs in a loop all the time
- Some new blocked ad elements
- Displays a popup when the plugin is first started, to suggest that the user deactivate their ad blocker on the YouTube site so that the plugin works
- Some improvements including #120
- As the plugin is not found on the Mozilla Firefox plugins site, so I took the liberty of publishing it here: https://addons.mozilla.org/firefox/addon/adskip-youtube/  (It's the same code, but it has a different name)
