### PR TITLE
added video.currentTime NaN handlin, and added element.childNodes null check

### DIFF
--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -146,7 +146,7 @@
                 const video = document.querySelector('video');
                 video.playbackRate = 10;
                 video.volume = 0;
-                video.currentTime = video.duration;
+                video.currentTime = isFinite(video.duration)? video.duration : 0; // handles NaN video duration
                 skipBtn?.click();
             }
 
@@ -159,7 +159,7 @@
             sponsor?.forEach((element) => {
                  if (element.getAttribute("id") === "panels") {
                     element.childNodes?.forEach((childElement) => {
-                      if (childElement.data.targetId && childElement.data.targetId !=="engagement-panel-macro-markers-description-chapters")
+                      if (childElement.data?.targetId && childElement.data.targetId !=="engagement-panel-macro-markers-description-chapters")
                           //Skipping the Chapters section
                             childElement.remove();
                           });


### PR DESCRIPTION
I added error handling for a few things that throw errors on my browser (Chromium). 

1) video.currentTime is not always finite (so either NaN or Infinite) and it throws in that case.
from the video.currentTime description: Returns the duration in seconds of the current media resource. A NaN value is returned if duration is not available, or Infinity if the media resource is streaming.

So with this change if video.currentTime is not finite just put 0 into it.

2) when element.childNodes is null it throws since there is no null checks for it.

So I added the null check for it. As far as I can tell this is a problem only in the yt homepage.