### PR TITLE
Update Youtube-Ad-blocker-Reminder-Remover.user.js v2.5

### DIFF
--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Remove Adblock Thing
 // @namespace    http://tampermonkey.net/
-// @version      2.4
+// @version      2.5
 // @description  Removes Adblock Thing
 // @author       JoelMatic
 // @match        https://www.youtube.com/*
@@ -11,8 +11,7 @@
 // @grant        none
 // ==/UserScript==
 
-(function()
- {
+(function () {
     //
     //      Config
     //
@@ -50,31 +49,49 @@
     };
 
     const keyEvent = new KeyboardEvent("keydown", {
-      key: "k",
-      code: "KeyK",
-      keyCode: 75,
-      which: 75,
-      bubbles: true,
-      cancelable: true,
-      view: window
+        key: "k",
+        code: "KeyK",
+        keyCode: 75,
+        which: 75,
+        bubbles: true,
+        cancelable: true,
+        view: window
     });
 
     let mouseEvent = new MouseEvent("click", {
-      bubbles: true,
-      cancelable: true,
-      view: window,
+        bubbles: true,
+        cancelable: true,
+        view: window,
     });
 
     //This is used to check if the video has been unpaused already
     let unpausedAfterSkip = 0;
 
+    //Allows elements to be deleted more quickly as soon as the page has just been loaded
+    const intervalChanger = {
+        addblocker: 10,
+        popupRemover: 100
+    }
+
+    setTimeout(() => {
+        //Reset to default
+        intervalChanger.addblocker = 50;
+        intervalChanger.popupRemover = 1000;
+    }, 5000);
+
     if (debug) console.log("Remove Adblock Thing: Remove Adblock Thing: Script started");
     // Old variable but could work in some cases
     window.__ytplayer_adblockDetected = false;
 
-    if(adblocker) addblocker();
-    if(removePopup) popupRemover();
-    if(removePopup) observer.observe(document.body, observerConfig);
+    if (adblocker) addblocker();
+    if (removePopup) popupRemover();
+
+    // Observe and remove ads when new content is loaded dynamically
+    const observer = new MutationObserver(() => {
+        removeJsonPaths(domainsToRemove, jsonPathsToRemove);
+    });
+
+    if (removePopup) observer.observe(document.body, observerConfig);
 
     // Remove Them pesski popups
     function popupRemover() {
@@ -102,15 +119,15 @@
             if (popup) {
                 if (debug) console.log("Remove Adblock Thing: Popup detected, removing...");
 
-                if(popupButton) popupButton.click();
+                if (popupButton) popupButton.click();
                 // if(popupButton2) popupButton2.click();
                 popup.remove();
                 unpausedAfterSkip = 2;
 
                 fullScreenButton.dispatchEvent(mouseEvent);
-              
+
                 setTimeout(() => {
-                  fullScreenButton.dispatchEvent(mouseEvent);
+                    fullScreenButton.dispatchEvent(mouseEvent);
                 }, 500);
 
                 if (debug) console.log("Remove Adblock Thing: Popup removed");
@@ -123,56 +140,91 @@
             unPauseVideo(video1);
             unPauseVideo(video2);
 
-        }, 1000);
+        }, intervalChanger.popupRemover);
     }
     // undetected adblocker method
-    function addblocker()
-    {
-        setInterval(() =>
-                    {
-            const skipBtn = document.querySelector('.videoAdUiSkipButton,.ytp-ad-skip-button');
-            const ad = [...document.querySelectorAll('.ad-showing')][0];
-            const sidAd = document.querySelector('ytd-action-companion-ad-renderer');
-            const displayAd = document.querySelector('div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint');
-            const sparklesContainer = document.querySelector('div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer');
-            const mainContainer = document.querySelector('div#main-container.style-scope.ytd-promoted-video-renderer');
-            const feedAd = document.querySelector('ytd-in-feed-ad-layout-renderer');
-            const mastheadAd = document.querySelector('.ytd-video-masthead-ad-v3-renderer');
-            const sponsor = document.querySelectorAll("div#player-ads.style-scope.ytd-watch-flexy, div#panels.style-scope.ytd-watch-flexy");
-            const nonVid = document.querySelector(".ytp-ad-skip-button-modern");
+    function addblocker() {
 
-            if (ad)
-            {
+        // Do not display as they will be deleted
+        const css =
+            `
+            .ad-showing, .videoAdUiSkipButton, .ytp-ad-skip-button, .ytp-ad-skip-button-modern { display: none; }
+            ytd-action-companion-ad-renderer { display: none; }
+            div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint { display: none; }
+            div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer { display: none; }
+            div#main-container.style-scope.ytd-promoted-video-renderer { display: none; }
+            ytd-in-feed-ad-layout-renderer { display: none; }
+            .ytd-video-masthead-ad-v3-renderer { display: none; }
+            ytd-engagement-panel-section-list-renderer[target-id="engagement-panel-ads"] { display: none; }
+            ytd-merch-shelf-renderer { display: none; }
+            .ytd-banner-promo-renderer { display: none; }
+            ytd-statement-banner-renderer, ytd-ad-slot-renderer { display: none; }
+        `;
+        const head = document.head || document.getElementsByTagName('head')[0];
+        const styleElement = document.createElement('style');
+        styleElement.type = 'text/css';
+        styleElement.id = 'adSkip'; // for debug: document.querySelector('#adSkip').remove()
+        styleElement.innerHTML = css;
+        head.appendChild(styleElement);
+
+        const skipBtnSelector = '.videoAdUiSkipButton, .ytp-ad-skip-button';
+        const adSelector = '.ad-showing';
+        const adRemovalSelectors = [
+            'ytd-action-companion-ad-renderer',
+            'div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint',
+            'div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer',
+            'div#main-container.style-scope.ytd-promoted-video-renderer',
+            'ytd-in-feed-ad-layout-renderer',
+            '.ytd-video-masthead-ad-v3-renderer',
+            'ytd-engagement-panel-section-list-renderer[target-id="engagement-panel-ads"]',
+            'ytd-merch-shelf-renderer', // Remove store stuff below videos : https://www.zupimages.net/up/23/45/1npf.png
+            '.ytd-banner-promo-renderer', // Removes the large banner that occasionally appears at the top of the home page offering to subscribe to Premium
+            'ytd-statement-banner-renderer', // removes large banners that occasionally appear in content on the home page offering to subscribe to Premium
+        ];
+        const sponsorSelectors = ['div#player-ads.style-scope.ytd-watch-flexy', 'div#panels.style-scope.ytd-watch-flexy'];
+        const nonVidSelector = '.ytp-ad-skip-button-modern';
+
+        setInterval(() => {
+            if (window.location.pathname !== '/') {
                 const video = document.querySelector('video');
-                video.playbackRate = 10;
-                video.volume = 0;
-                video.currentTime = video.duration;
-                skipBtn?.click();
+                const skipBtn = document.querySelector(skipBtnSelector);
+                const ad = document.querySelector(adSelector);
+
+                if (ad) {
+                    video.playbackRate = 10;
+                    video.volume = 0;
+                    video.currentTime = video.duration;
+                    skipBtn?.click();
+                }
             }
 
-            sidAd?.remove();
-            displayAd?.remove();
-            sparklesContainer?.remove();
-            mainContainer?.remove();
-            feedAd?.remove();
-            mastheadAd?.remove();
-            sponsor?.forEach((element) => {
-                 if (element.getAttribute("id") === "panels") {
+
+            for (const removalSelector of adRemovalSelectors) {
+                const element = document.querySelector(removalSelector);
+                element?.remove();
+            }
+
+            const sponsorElements = document.querySelectorAll(sponsorSelectors.join(', '));
+            sponsorElements.forEach((element) => {
+                if (element.getAttribute("id") === "panels") {
                     element.childNodes?.forEach((childElement) => {
-                      if (childElement.data.targetId && childElement.data.targetId !=="engagement-panel-macro-markers-description-chapters")
-                          //Skipping the Chapters section
+                        if (childElement.data?.targetId && childElement.data.targetId !== "engagement-panel-macro-markers-description-chapters") {
+                            //Skipping the Chapters section
                             childElement.remove();
-                          });
-                       } else {
-                           element.remove();
-                       }
-             });
+                        }
+                    });
+                } else {
+                    element.remove();
+                }
+            });
+
+            const nonVid = document.querySelector(nonVidSelector);
             nonVid?.click();
-        }, 50)
+        }, intervalChanger.addblocker);
     }
+
     // Unpause the video Works most of the time
-    function unPauseVideo(video)
-    {
+    function unPauseVideo(video) {
         if (!video) return;
         if (video.paused) {
             // Simulate pressing the "k" key to unpause the video
@@ -181,8 +233,7 @@
             if (debug) console.log("Remove Adblock Thing: Unpaused video using 'k' key");
         } else if (unpausedAfterSkip > 0) unpausedAfterSkip--;
     }
-    function removeJsonPaths(domains, jsonPaths)
-    {
+    function removeJsonPaths(domains, jsonPaths) {
         const currentDomain = window.location.hostname;
         if (!domains.includes(currentDomain)) return;
 
@@ -191,7 +242,7 @@
             let obj = window;
             let previousObj = null;
             let partToSetUndefined = null;
-        
+
             for (const part of pathParts) {
                 if (obj.hasOwnProperty(part)) {
                     previousObj = obj; // Keep track of the parent object.
@@ -201,16 +252,14 @@
                     break; // Stop when we reach a non-existing part.
                 }
             }
-        
+
             // If we've identified a valid part to set to undefined, do so.
             if (previousObj && partToSetUndefined !== null) {
                 previousObj[partToSetUndefined] = undefined;
             }
         });
     }
-    // Observe and remove ads when new content is loaded dynamically
-    const observer = new MutationObserver(() =>
-    {
-        removeJsonPaths(domainsToRemove, jsonPathsToRemove);
-    });
+
+
+
 })();

--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -67,18 +67,6 @@
     //This is used to check if the video has been unpaused already
     let unpausedAfterSkip = 0;
 
-    //Allows elements to be deleted more quickly as soon as the page has just been loaded
-    const intervalChanger = {
-        addblocker: 10,
-        popupRemover: 100
-    }
-
-    setTimeout(() => {
-        //Reset to default
-        intervalChanger.addblocker = 50;
-        intervalChanger.popupRemover = 1000;
-    }, 5000);
-
     if (debug) console.log("Remove Adblock Thing: Remove Adblock Thing: Script started");
     // Old variable but could work in some cases
     window.__ytplayer_adblockDetected = false;
@@ -140,7 +128,7 @@
             unPauseVideo(video1);
             unPauseVideo(video2);
 
-        }, intervalChanger.popupRemover);
+        }, 1000);
     }
     // undetected adblocker method
     function addblocker() {
@@ -220,7 +208,7 @@
 
             const nonVid = document.querySelector(nonVidSelector);
             nonVid?.click();
-        }, intervalChanger.addblocker);
+        }, 50);
     }
 
     // Unpause the video Works most of the time


### PR DESCRIPTION
Update to the code, here is the summary:

- By default, the two `setInterval` functions are set to 1000 and 50 milliseconds. However, now, upon loading each page, they are set to 100 (instead of 1000) and 10 milliseconds (instead of 50) in an attempt to remove ads even more quickly. I had the idea to create an intervalChanger to restore the old values of 1000 and 50 after 5 seconds once the page is loaded.
- I placed `new MutationObserver()` before `observer.observe` because there are sometimes initialization errors.
- Injects CSS code to hide all ads with `display: none` since they will be removed, might as well hide them.
- I added an `if (window.location.pathname !== '/')` in the `setInterval` to avoid checking if a video exists on the homepage because it does not. This is good for performance.
- IDs, elements, and classes are now stored in arrays.

To test the code on Firefox:  https://addons.mozilla.org/firefox/addon/adskip-youtube/ it's the same code