### PR TITLE
fix - playback speed retain

### DIFF
--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -148,12 +148,12 @@
                 removePageAds();
             }
 
+            var video = document.querySelector('video');
+            var videoPlayback = video.playbackRate
             if (ad)
             {
 
                 if (debugMessages) console.log("Remove Adblock Thing: Found Ad");
-
-                const video = document.querySelector('video');
 
                 const skipBtn = document.querySelector('.videoAdUiSkipButton,.ytp-ad-skip-button');
                 const nonVid = document.querySelector(".ytp-ad-skip-button-modern");
@@ -183,6 +183,10 @@
                 if (popupContainer) popupContainer.style.display = "block";
 
                 if (debugMessages) console.log("Remove Adblock Thing: skipped Ad (✔️)");
+            } else {
+                if(video.playbackRate == 10){
+                    video.playbackRate = videoPlayback
+                }
             }
 
         }, 50)


### PR DESCRIPTION
The issue occurs when I am watching a video, and the playback speed becomes 10x after an ad. It does not return to the original speed in which I was watching. I fixed this issue by changing the original speed after skipping the ad.