### PR TITLE
Fix : Screen flickering between darker and ligher

### DIFF
--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -163,6 +163,8 @@
                 const blockAdButtonConfirm = document.querySelector('.Eddif [label="CONTINUE"] button');
                 const closeAdCenterButton = document.querySelector('.zBmRhe-Bz112c');
 
+                const hidebackdrop = document.querySelector("body > tp-yt-iron-overlay-backdrop");
+
                 if (video) video.playbackRate = 10;
                 if (video) video.volume = 0;
                 if (video) video.currentTime = video.duration || 0;
@@ -174,7 +176,10 @@
 
                 var popupContainer = document.querySelector('body > ytd-app > ytd-popup-container > tp-yt-paper-dialog');
 
-                if (popupContainer) popupContainer.style.display = 'none';
+                if (popupContainer) {
+                  popupContainer.style.display = 'none';
+                  hidebackdrop.style.display = 'none';
+              }
 
                 blockAdButton?.click();
                 blockAdButtonConfirm?.click();


### PR DESCRIPTION
This pull request addresses the flickering issue we were encountering on YouTube. The `tp-yt-iron-overlay-backdrop` div was causing the problem. Simply adding `display: none` to it eliminates the gray flickering that several users were experiencing

**Issue link :** 
#251 