### PR TITLE
chore: created a modal for 'update version' popup, if clicked skip, doesn't appear again until next version

### DIFF
--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -30,6 +30,8 @@
     const debugMessages = true;
 
     // Enable custom modal
+    // Uses SweetAlert2 library (https://cdn.jsdelivr.net/npm/sweetalert2@11) for the update version modal.
+    // When set to false, the default window popup will be used. And the library will not be loaded.
     const updateModal = {
         enable: true, // if true, replaces default window popup with a custom modal
         timer: 5000, // timer: number | false
@@ -397,6 +399,12 @@
                             });
                         };
 
+                        script.onerror = function () {
+                            var result = window.confirm("Remove Adblock Thing: A new version is available. Please update your script.");
+                            if (result) {
+                                window.location.replace(scriptUrl);
+                            }
+                        }
                     } else {
                         var result = window.confirm("Remove Adblock Thing: A new version is available. Please update your script.");
 

--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -29,6 +29,12 @@
     // Enable debug messages into the console
     const debugMessages = true;
 
+    // Enable custom modal
+    const updateModal = {
+        enable: true, // if true, replaces default window popup with a custom modal
+        timer: 5000, // timer: number | false
+    };
+    
     //
     //      CODE
     //
@@ -349,11 +355,56 @@
                 if (githubVersion > currentVersion) {
                     console.log('Remove Adblock Thing: A new version is available. Please update your script.');
 
-                    var result = window.confirm("Remove Adblock Thing: A new version is available. Please update your script.");
+                    if(updateModal.enable){
+                        // if a version is skipped, don't show the update message again until the next version
+                        if (parseFloat(localStorage.getItem('skipRemoveAdblockThingVersion')) === githubVersion) {
+                            return;
+                        }
+                        // If enabled, include the SweetAlert2 library
+                        const script = document.createElement('script');
+                        script.src = 'https://cdn.jsdelivr.net/npm/sweetalert2@11';
+                        document.head.appendChild(script);
 
-                    if (result) {
-                        window.location.replace(scriptUrl);
+                        const style = document.createElement('style');
+                        style.textContent = '.swal2-container { z-index: 2400; }';
+                        document.head.appendChild(style);
+
+                        // Wait for SweetAlert to be fully loaded
+                        script.onload = function () {
+
+                            Swal.fire({
+                                position: "top-end",
+                                backdrop: false,
+                                title: 'Remove Adblock Thing: New version is available.',
+                                text: 'Do you want to update?',
+                                showCancelButton: true,
+                                showDenyButton: true,
+                                confirmButtonText: 'Update',
+                                denyButtonText:'Skip',
+                                cancelButtonText: 'Close',
+                                timer: updateModal.timer ?? 5000,
+                                timerProgressBar: true,
+                                didOpen: (modal) => {
+                                    modal.onmouseenter = Swal.stopTimer;
+                                    modal.onmouseleave = Swal.resumeTimer;
+                                }
+                            }).then((result) => {
+                                if (result.isConfirmed) {
+                                    window.location.replace(scriptUrl);
+                                } else if(result.isDenied) {
+                                    localStorage.setItem('skipRemoveAdblockThingVersion', githubVersion);
+                                }
+                            });
+                        };
+
+                    } else {
+                        var result = window.confirm("Remove Adblock Thing: A new version is available. Please update your script.");
+
+                        if (result) {
+                            window.location.replace(scriptUrl);
+                        }
                     }
+
 
                 } else {
                     console.log('Remove Adblock Thing: You have the latest version of the script.');


### PR DESCRIPTION
[Inspired from PR #269 discussion]

features:
- SweetAlert2 modal (instead of an 'alert dialog which is a blocking action')
- If clicked 'skip' on the modal, the skipped version is stored locally, the modal doesn't appear until there is a newer version released other than the skipped version.
- there is a default 5-second timer, it dismisses if there is no interaction, and can be changed/disabled from the config mentioned below.
- can be disabled at the start of the script:
```js
// Enable custom modal
    const updateModal = {
        enable: true, // if true, replaces default window popup with a custom modal
        timer: 5000, // timer: number | false
    };
```

https://github.com/TheRealJoelmatic/RemoveAdblockThing/assets/74111241/95c1fd7a-7a9e-4925-90d4-aea053f8ce0c


_ps: first time using tampermonkey, open for suggestions about the implementation_