### PR TITLE
fixed two audio streams playing simultaneously

### DIFF
--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -225,10 +225,11 @@
         }
     
         videoPlayerElements.forEach(videoPlayerElement => {
-            while (videoPlayerElement.firstChild) {
-                videoPlayerElement.removeChild(videoPlayerElement.firstChild);
-            }
+        const iframes = videoPlayerElement.querySelectorAll('iframe');
+        iframes.forEach(iframe => {
+            iframe.remove();
         });
+    });
     
         console.log("Removed all current players!");
         return true;


### PR DESCRIPTION
Modified the `clearAllPlayers` function..

By removing all existing `iframe` elements from the video player container before creating a new one, ensures that there is only one video player at a time.