### PR TITLE
Fixes unplayable video in safari because the video is behind the error screen

### DIFF
--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -150,6 +150,14 @@
                 return;
             }
 
+            /**
+             * remove the "Ad blockers violate YouTube's Terms of Service" screen for safari
+             */
+            let errorScreen = document.querySelector("#error-screen");
+            if (errorScreen) {
+                errorScreen.remove();
+            }
+            
             //
             // Get the url
             //


### PR DESCRIPTION
This fix removes the error screen that says "Ad blockers violate YouTube's Terms of Service" since it is on top of the video