### PR TITLE
Less random related videos

### DIFF
--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -181,7 +181,7 @@
             //
 
             const startOfUrl = "https://www.youtube-nocookie.com/embed/";
-            const endOfUrl = "?autoplay=1&modestbranding=1";
+            const endOfUrl = "?autoplay=1&modestbranding=1&rel=0";
             const finalUrl = startOfUrl + videoID + endOfUrl;
 
             const iframe = document.createElement('iframe');


### PR DESCRIPTION
![image](https://github.com/TheRealJoelmatic/RemoveAdblockThing/assets/149953009/96e5354e-3f37-44a1-a14b-9384bcb74bc4)
This PR adds the `rel=0` parameter, to force the related videos that appear once you pause the video to come from the same channel as the video that was just played.

https://github.com/TheRealJoelmatic/RemoveAdblockThing/issues/572
