### PR TITLE
Prevents Adblock from messing with or breaking YouTube Shorts

### DIFF
--- a/Youtube-Ad-blocker-Reminder-Remover.user.js
+++ b/Youtube-Ad-blocker-Reminder-Remover.user.js
@@ -4,7 +4,7 @@
 // @version      5.6
 // @description  Removes Adblock Thing
 // @author       JoelMatic
-// @match        https://www.youtube.com/*
+// @match        https://*.youtube.com/watch?v=*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=youtube.com
 // @updateURL    https://github.com/TheRealJoelmatic/RemoveAdblockThing/raw/main/Youtube-Ad-blocker-Reminder-Remover.user.js
 // @downloadURL  https://github.com/TheRealJoelmatic/RemoveAdblockThing/raw/main/Youtube-Ad-blocker-Reminder-Remover.user.js


### PR DESCRIPTION
Adblock often blocks Short ads after they load, resulting in skipping videos.